### PR TITLE
docs: add personas and business needs for content organization

### DIFF
--- a/docs/personas-and-business-needs.md
+++ b/docs/personas-and-business-needs.md
@@ -1,0 +1,141 @@
+# Personas and Business Needs for Mainframe Modernization
+
+This document maps common reader roles/personas to their primary business needs and
+topics of interest. It is intended to guide how we organize and present modernization
+content so it is most useful to each audience segment.
+
+The three core business need categories used throughout this guide are:
+
+- **Faster Delivery** — Accelerating time-to-market and development velocity
+- **Better Insights** — Gaining visibility, observability, and data-driven decision-making
+- **Cost Savings** — Reducing operational expense and optimizing ROI
+
+---
+
+## 1. Chief Technology Officer (CTO) / VP of Engineering
+
+**Goal:** Drive the organization's technology strategy and justify modernization
+investments to the business.
+
+| Business Need | Topics of Interest |
+|---|---|
+| **Faster Delivery** | Hybrid cloud integration strategies; API-enabling mainframe applications; DevOps adoption for mainframe teams; reducing time-to-market for new features |
+| **Better Insights** | Executive dashboards for application portfolio health; AI/ML leverage for strategic decisions; benchmarking modernization progress against business KPIs |
+| **Cost Savings** | ROI-driven modernization business cases; Total Cost of Ownership (TCO) analysis for mainframe vs. cloud; cost modeling for phased migration vs. replatforming |
+
+---
+
+## 2. Enterprise Architect
+
+**Goal:** Design the target-state architecture that connects mainframe systems with
+modern cloud-native services while preserving existing investments.
+
+| Business Need | Topics of Interest |
+|---|---|
+| **Faster Delivery** | Strangler Fig and incremental modernization patterns; event-driven integration (Kafka, MQ); mainframe-as-API patterns using REST/GraphQL |
+| **Better Insights** | Application dependency mapping; portfolio assessment tools; identifying modernization candidates vs. systems to retain |
+| **Cost Savings** | Avoiding big-bang rewrites; reuse of existing COBOL/PL1 business logic; hybrid cloud reference architectures that optimize licensing |
+
+---
+
+## 3. Application Developer
+
+**Goal:** Build, refactor, or integrate mainframe applications using modern toolchains
+and practices without disrupting existing services.
+
+| Business Need | Topics of Interest |
+|---|---|
+| **Faster Delivery** | CI/CD pipelines for mainframe (Zowe CLI, IBM DBB); automated testing for COBOL and PL/I; IDEs and VS Code extensions for mainframe development |
+| **Better Insights** | Code quality and static analysis for legacy languages; understanding application behavior through distributed tracing |
+| **Cost Savings** | Leveraging open-source tooling (Zowe, Open Mainframe Project ecosystem); reuse of existing business logic during modernization |
+
+---
+
+## 4. System Administrator (SysAdmin) / z/OS Systems Programmer
+
+**Goal:** Keep mainframe systems stable, secure, and performant while supporting
+modernization efforts.
+
+| Business Need | Topics of Interest |
+|---|---|
+| **Faster Delivery** | Infrastructure-as-Code (IaC) for z/OS provisioning; automating JCL and job scheduling; reducing manual change management overhead |
+| **Better Insights** | SMF data analysis and real-time monitoring; log aggregation into shared observability stacks (e.g., Splunk, ELK); capacity planning |
+| **Cost Savings** | MIPS/MSU optimization; workload offloading to distributed platforms; automated resource tuning |
+
+---
+
+## 5. IT / Operations Manager
+
+**Goal:** Ensure reliable delivery of IT services, manage the modernization program,
+and demonstrate progress to leadership.
+
+| Business Need | Topics of Interest |
+|---|---|
+| **Faster Delivery** | Agile program management for mainframe modernization initiatives; team upskilling and workforce transition planning |
+| **Better Insights** | Modernization KPIs and progress dashboards; risk and dependency tracking across teams |
+| **Cost Savings** | Budget planning for phased modernization; vendor and contract management (ISV licensing, cloud credits) |
+
+---
+
+## 6. Chief Information Security Officer (CISO) / Security Officer
+
+**Goal:** Ensure that modernization does not introduce new security vulnerabilities
+and that compliance obligations are maintained throughout the transition.
+
+| Business Need | Topics of Interest |
+|---|---|
+| **Faster Delivery** | Shift-left security practices for mainframe pipelines; integrating RACF/ACF2 policies with cloud IAM; automated compliance scanning |
+| **Better Insights** | Security information and event management (SIEM) integration; audit trail continuity during migration; threat modeling for hybrid architectures |
+| **Cost Savings** | Consolidating security tooling across mainframe and cloud; reducing audit overhead through automation; risk-based prioritization of security controls |
+
+---
+
+## 7. Business Analyst / Product Owner
+
+**Goal:** Translate business requirements into modernization priorities and measure
+business value delivered.
+
+| Business Need | Topics of Interest |
+|---|---|
+| **Faster Delivery** | Identifying high-value applications for early modernization; agile requirements practices that bridge business and mainframe teams |
+| **Better Insights** | Business process impact analysis; data access modernization for analytics and reporting; customer-facing outcome metrics |
+| **Cost Savings** | Cost-benefit analysis of modernization options; prioritizing initiatives by business value vs. technical risk |
+
+---
+
+## 8. Data Engineer / Data Architect
+
+**Goal:** Modernize access to mainframe data for analytics, real-time processing, and
+AI/ML workloads without disrupting transactional systems.
+
+| Business Need | Topics of Interest |
+|---|---|
+| **Faster Delivery** | Change Data Capture (CDC) from Db2 z/OS and VSAM; real-time data streaming to cloud data lakes; modernizing batch ETL to event-driven pipelines |
+| **Better Insights** | Mainframe data cataloging and lineage; integrating z/OS data into enterprise data platforms (Databricks, BigQuery, Snowflake) |
+| **Cost Savings** | Offloading analytics workloads from the mainframe; eliminating costly report-only batch jobs; reducing data silos |
+
+---
+
+## Summary Matrix
+
+| Persona | Faster Delivery | Better Insights | Cost Savings |
+|---|---|---|---|
+| CTO / VP Engineering | ✅ High | ✅ High | ✅ High |
+| Enterprise Architect | ✅ High | ✅ High | ✅ Medium |
+| Application Developer | ✅ High | ✅ Medium | ✅ Medium |
+| SysAdmin / z/OS Programmer | ✅ Medium | ✅ High | ✅ High |
+| IT / Ops Manager | ✅ Medium | ✅ High | ✅ High |
+| CISO / Security Officer | ✅ Medium | ✅ High | ✅ Medium |
+| Business Analyst / Product Owner | ✅ Medium | ✅ High | ✅ High |
+| Data Engineer / Architect | ✅ High | ✅ High | ✅ Medium |
+
+---
+
+## Notes on Usage
+
+- Content pages should clearly identify which **persona(s)** they are most relevant to
+  (e.g., a front-matter tag like `audience: developer, sysadmin`).
+- Navigation and landing pages should allow readers to self-select their role and be
+  directed to the most relevant content.
+- A single piece of content may serve multiple personas; the matrix above can help
+  identify natural groupings.


### PR DESCRIPTION
Maps 8 reader personas (CTO, Enterprise Architect, Developer, SysAdmin, IT Manager, CISO, Business Analyst, Data Engineer) to the three core business need categories: Faster Delivery, Better Insights, Cost Savings.

Topics are tailored to the mainframe modernization context including z/OS-specific tooling (Zowe, IBM DBB, RACF, SMF), hybrid cloud patterns, and OMP ecosystem tools.

Closes #<issue-number>