### PR TITLE
ci: add frontmatter validation workflow for framework/ documents

### DIFF
--- a/.github/scripts/validate_frontmatter.py
+++ b/.github/scripts/validate_frontmatter.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Validates YAML frontmatter for framework/ documents against the schema
+defined in CONTENT_SCHEMA.md.
+
+Usage:
+    python validate_frontmatter.py <file1.md> [file2.md ...]
+
+Exit codes:
+    0 — all files pass
+    1 — one or more validation errors found
+    2 — script invocation error
+"""
+
+import re
+import sys
+
+try:
+    import frontmatter
+except ImportError:
+    print("error: python-frontmatter is not installed (pip install python-frontmatter)")
+    sys.exit(2)
+
+
+ALLOWED_DOMAINS = {
+    "applications",
+    "data",
+    "operations",
+    "interoperability",
+    "security",
+}
+
+ALLOWED_STATUSES = {"draft", "review", "approved"}
+
+# Matches MAJOR.MINOR — e.g. "0.1", "1.0"
+VERSION_RE = re.compile(r"^\d+\.\d+$")
+
+# Matches ISO-8601 calendar date — e.g. "2024-06-01"
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+# Fields requiring non-empty values once a document leaves draft
+STRICT_STATUSES = {"review", "approved"}
+
+
+def validate(path: str) -> list[str]:
+    errors = []
+
+    try:
+        with open(path, encoding="utf-8") as fh:
+            post = frontmatter.load(fh)
+    except Exception as exc:
+        return [f"{path}: malformed frontmatter — {exc}"]
+
+    meta = post.metadata
+
+    # --- Fields required at every lifecycle stage ---
+
+    title = meta.get("title", "")
+    if not isinstance(title, str) or not title.strip():
+        errors.append(
+            f"{path}: 'title' must be a non-empty string — got {title!r}"
+        )
+
+    domain = meta.get("domain", "")
+    if domain not in ALLOWED_DOMAINS:
+        errors.append(
+            f"{path}: 'domain' invalid — got {domain!r}, "
+            f"expected one of: {', '.join(sorted(ALLOWED_DOMAINS))}"
+        )
+
+    status = meta.get("status", "")
+    if status not in ALLOWED_STATUSES:
+        errors.append(
+            f"{path}: 'status' invalid — got {status!r}, "
+            f"expected one of: {', '.join(sorted(ALLOWED_STATUSES))}"
+        )
+
+    version = str(meta.get("version", ""))
+    if not VERSION_RE.match(version):
+        errors.append(
+            f"{path}: 'version' must match MAJOR.MINOR (e.g. '0.1') — got {version!r}"
+        )
+
+    # --- Additional fields required for review and approved documents ---
+
+    if status in STRICT_STATUSES:
+        authors = meta.get("authors", [])
+        if not isinstance(authors, list) or len(authors) == 0:
+            errors.append(
+                f"{path}: 'authors' must be a non-empty list "
+                f"when status is {status!r} — got {authors!r}"
+            )
+
+        last_updated = str(meta.get("last-updated", ""))
+        if not DATE_RE.match(last_updated):
+            errors.append(
+                f"{path}: 'last-updated' must be a valid ISO-8601 date (YYYY-MM-DD) "
+                f"when status is {status!r} — got {last_updated!r}"
+            )
+
+    return errors
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("usage: validate_frontmatter.py <file> [file ...]")
+        sys.exit(2)
+
+    paths = sys.argv[1:]
+    all_errors: list[str] = []
+
+    for path in paths:
+        file_errors = validate(path)
+        all_errors.extend(file_errors)
+
+    if all_errors:
+        print("Frontmatter validation failed:\n")
+        for err in all_errors:
+            print(f"  ✗ {err}")
+        print(f"\n{len(all_errors)} error(s) found.")
+        sys.exit(1)
+
+    print(f"Frontmatter validation passed ({len(paths)} file(s) checked).")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/validate-content.yml
+++ b/.github/workflows/validate-content.yml
@@ -1,0 +1,42 @@
+name: Validate framework frontmatter
+
+on:
+  pull_request:
+    paths:
+      - 'framework/**'
+
+jobs:
+  frontmatter:
+    name: Check frontmatter schema
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install python-frontmatter==1.1.0
+
+      - name: Collect changed framework files
+        id: changed
+        run: |
+          files=$(git diff --name-only --diff-filter=AM \
+            "origin/${{ github.base_ref }}...HEAD" -- 'framework/' \
+            | grep '\.md$' | tr '\n' ' ')
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+
+      - name: Validate frontmatter
+        if: steps.changed.outputs.files != ''
+        run: |
+          python .github/scripts/validate_frontmatter.py ${{ steps.changed.outputs.files }}
+
+      - name: No framework files changed
+        if: steps.changed.outputs.files == ''
+        run: echo "No framework/*.md files changed — skipping validation."


### PR DESCRIPTION
## Summary

`CONTENT_SCHEMA.md` defines the frontmatter contract for all documents
under `framework/` — required fields, allowed enum values, version
formatting, and lifecycle-gated requirements. Nothing currently enforces
this contract at PR time; a contributor can merge a document with an
invalid `domain`, a non-canonical `status`, or empty required fields
without any CI feedback.

This PR adds the enforcement layer proposed in #27. It is also the
natural tooling follow-up to the schema definition work in #25.

Closes #27


## What's included

- `.github/workflows/validate-content.yml` — triggers on PRs that touch
  `framework/**`; collects added/modified `.md` files and runs the
  validator script
- `.github/scripts/validate_frontmatter.py` — validates each file's
  frontmatter; exits non-zero with per-field error output on failure


## Validation rules

**All lifecycle stages (`draft`, `review`, `approved`):**
- `title` — non-empty string
- `domain` — one of `applications | data | operations | interoperability | security`
- `status` — one of `draft | review | approved`
- `version` — matches `MAJOR.MINOR` (e.g. `0.1`)

**`review` and `approved` only:**
- `authors` — non-empty list
- `last-updated` — valid ISO-8601 date (`YYYY-MM-DD`)

The lifecycle split is intentional: the five existing stubs carry
`status: draft` with empty `authors` and `last-updated`. Blanket
enforcement would fail them on every PR. Scoping the strict checks to
`review`/`approved` matches how the review criteria in `CONTENT_SCHEMA.md`
actually read, and keeps existing content passing without modification.


## Error output

Failures identify the file, field, and received value:

```
Frontmatter validation failed:

  ✗ framework/security.md: 'domain' invalid — got 'sec', expected one of: applications, data, interoperability, operations, security
  ✗ framework/security.md: 'status' invalid — got 'in-review', expected one of: approved, draft, review

2 error(s) found.
```

Malformed YAML frontmatter (unparseable blocks) also fails explicitly
rather than silently passing.


## Testing

Validated locally against all five existing framework stubs — all pass
under the lifecycle-aware rules. Tested the following failure cases
directly against the script:

- invalid `domain` value → caught
- non-canonical `status` value → caught
- malformed version string → caught
- empty `authors` on a `review`-status document → caught
- missing `last-updated` on an `approved`-status document → caught
- malformed YAML block → caught with parse error message


## Checklist

- [x] The affected document(s) are identified (`.github/` only — no `framework/` content changed)
- [x] The domain is correct (`cross-cutting`)
- [x] Content is factually accurate and consistent with `modernization-definition.md`
- [x] Terminology is consistent with existing framework documents
- [x] I have reviewed my own changes before requesting a review